### PR TITLE
fixed url, google has moved the form to a subdomain

### DIFF
--- a/lib/goog_currency.rb
+++ b/lib/goog_currency.rb
@@ -9,7 +9,7 @@ module GoogCurrency
       raise NoMethodException, "GoogCurrency accepts methods in 'usd_to_inr' or 'gbp_to_usd' format"
     end
 
-    response = open("http://www.google.com/finance/converter?a=#{args.first}&from=#{from.upcase}&to=#{to.upcase}").read
+    response = open("http://finance.google.com/finance/converter?a=#{args.first}&from=#{from.upcase}&to=#{to.upcase}").read
     handle_response(response)
   end
 


### PR DESCRIPTION
Today a bunch of my sites broke because this gem was not working anymore. After some digging, turns out the google form used moved to a subdomain (finance.google.com), the rest remains identical, and updating the url fixes the problem, so i created an account on github, forked, fixed and here's the pull request :)